### PR TITLE
feat(ENFDI-166): update sendEmailOtp and verifyEmailOtp APIs to V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import { TransakAPI } from './lib/index.js';
 // Optionally, if TransakAPI needs configuration, pass it here (e.g., your API key, base URL, etc.)
 const transakSdk = new TransakAPI({
     environment: 'staging',
-    partnerApiKey: 'a2374be4-c59a-400e-809b-72c226c74b8f',
+    partnerApiKey: '0b4a8ff3-0d7e-409b-a6b9-3b82094b0f03',
 });
 
 ```
@@ -60,7 +60,7 @@ const transakSdk = new TransakAPI({
 
 **Getting Started**
 
-To use this function, you must first **request a** `frontendAuth` &  ****`partnerApiKey` **Key** from Transak. You can obtain it by reaching out to: **Sales Team:** [sales@transak.com](mailto:sales@transak.com).  Once you receive your **Partner** **API key** and **Frontend Auth token**, you can pass them in the request along with the **user’s email address**.
+To use this function, you must first **request a** `partnerApiKey` **Key** from Transak. You can obtain it by reaching out to: **Sales Team:** [sales@transak.com](mailto:sales@transak.com).  Once you receive your **Partner** **API key**, you can pass them in the request along with the **user’s email address**.
 
 **How It Works**
 
@@ -76,21 +76,25 @@ The `sendEmailOtp` function is a **non-authenticated** API method that allows yo
 **Example Usage**
 
 ```jsx
-await transak.user.sendEmailOtp({ email: 'user@example.com', frontendAuth: 'your-frontend-auth' });
+await transak.user.sendEmailOtp({ email: 'user@example.com', apiKey: 'partner-api-key' });
 ```
 
 > Response Output Fields:
 > 
 
 ```json
-{ "isTncAccepted": "boolean" }
+{ "isTncAccepted": "boolean",
+  "stateToken": "string",
+  "email": "string",
+  "expiresIn": "integer"
+}
 ```
 
 ### **Verify Email OTP**
 
 The `verifyEmailOtp` is a **non-authenticated API** that allows you to **verify a user’s email using an OTP** and retrieve an **access token** in return.
 
-Once you have successfully called `sendEmailOtp`, you need to pass the **email verification code** along with the user’s email to **verify the OTP**.
+Once you have successfully called `sendEmailOtp`, you need to pass the **otp** & **stateToken** along with the user’s email to **verify the OTP**.
 
 **Access Token Usage**
 
@@ -101,8 +105,10 @@ Once you have successfully called `sendEmailOtp`, you need to pass the **email v
 
 ```jsx
 const response = await transak.user.verifyEmailOtp({
+    apiKey: 'partner-api-key',
     email: 'user@example.com',
-    emailVerificationCode: '123456'
+    otp: '123456',
+    stateToken: 'state-token-from-sendEmailOtp-response'
 });
 console.log(response);
 ```
@@ -112,10 +118,9 @@ console.log(response);
 
 ```json
 {
-  "id": "string", // ID is equal to the user's access token
+  "accessToken": "string", //user's access token for authenticated API calls
   "ttl": "number", // TTL is generally the TTL of the access token; access token expiry is generally 30 days from generation
-  "created": "string", // Date created means date-time
-  "userId": "string"
+  "created": "string"
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17708,16 +17708,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/src/EmailVerification.js
+++ b/src/EmailVerification.js
@@ -4,11 +4,12 @@ import { TransakAPI } from './lib/index.js';
 // Optionally, if TransakAPI needs configuration, pass it here (e.g., your API key, base URL, etc.)
 const transakSdk = new TransakAPI({
     environment: 'staging',
-    partnerApiKey: 'a2374be4-c59a-400e-809b-72c226c74b8f',
+    partnerApiKey: '0b4a8ff3-0d7e-409b-a6b9-3b82094b0f03',
 });
 
 const EmailVerification = () => {
   const [email, setEmail] = useState('');
+  const [stateToken, setStateToken] = useState('');
   const [token, setToken] = useState('');
   const [message, setMessage] = useState('');
   const [verificationStatus, setVerificationStatus] = useState('');
@@ -17,9 +18,9 @@ const EmailVerification = () => {
   const handleSendEmail = async () => {
     try {
       // Replace with the actual method provided by the Transak API client.
-      const frontendAuth = `9TRUtEM_RLns4Tp7h34wtvA2h*yc2ty2EhChtWtAdRko!EpVrpvH26xf_YJPM_qqiEG4LsL7TJiB6wg79BjtLGHdaKu6gHsceDHQ`
-      const response = await transakSdk.user.sendEmailOtp({ email, frontendAuth });
+      const response = await transakSdk.user.sendEmailOtp({ email });
       console.log(response)
+      setStateToken(response.stateToken)
       setMessage(`Verification email sent to ${email}. Please check your inbox.`);
     } catch (error) {
       setMessage(`Error sending verification email: ${error.message}`);
@@ -29,9 +30,11 @@ const EmailVerification = () => {
   // Function to call the API to verify the email using a token
   const handleVerifyEmail = async () => {
     try {
-      // Replace with the actual method provided by the Transak API client.
-      const response = await transakSdk.user.verifyEmailOtp({ email, 
-        emailVerificationCode: token });
+      const response = await transakSdk.user.verifyEmailOtp({
+        email: email,
+        otp: token,
+        stateToken: stateToken
+      });
       if (response.created) {
         setVerificationStatus('Email verified successfully!');
       } else {

--- a/src/lib/ApiClient.js
+++ b/src/lib/ApiClient.js
@@ -60,7 +60,8 @@ class ApiClient {
           )
         ),
         'Content-Type': 'application/json',
-        'x-trace-id': this.traceId,
+        //Todo: Commented due to cors error
+        //'x-trace-id': this.traceId,
       };
 
       const requestConfig = {

--- a/src/lib/constants/apiSpecs/user_api_specs.js
+++ b/src/lib/constants/apiSpecs/user_api_specs.js
@@ -151,22 +151,22 @@ const apiSpecs = {
   send_email_otp: {
     name: 'Send Email OTP',
     id: 'send_email_otp',
-    url: '/api/v2/user/email/send',
+    url: '/api/v2/auth/login',
     method: 'POST',
     headers: {
       'x-trace-id': 'string',
-      'frontend-auth': 'string',
       accept: 'application/json',
       'content-type': 'application/json',
     },
     expected_status: 200,
     body: {
       email: { type: 'string', isRequired: 'true', value: '' },
-      partnerApiKey: { type: 'string', isRequired: 'true', value: '' },
+      apiKey: { type: 'string', isRequired: 'true', value: '' },
     },
-    response_root_field_name: 'response',
+    response_root_field_name: 'data',
     response_required_fields: {
       isTncAccepted: 'boolean',
+      stateToken: 'string',
     },
     response_optional_fields: {},
     output_fields: {
@@ -175,12 +175,17 @@ const apiSpecs = {
         type: 'boolean',
         isRequired: true,
       },
+      stateToken: {
+        source: 'stateToken',
+        type: 'string',
+        isRequired: true,
+      }
     },
   },
   verify_email_otp: {
     name: 'Verify Email OTP',
     id: 'verify_email_otp',
-    url: '/api/v2/user/email/verify',
+    url: '/api/v2/auth/verify',
     method: 'POST',
     headers: {
       'x-trace-id': 'string',
@@ -189,23 +194,22 @@ const apiSpecs = {
     },
     expected_status: 200,
     body: {
-      partnerApiKey: { type: 'string', isRequired: 'true', value: '' },
+      apiKey: { type: 'string', isRequired: 'true', value: '' },
       email: { type: 'string', isRequired: 'true', value: '' },
-      emailVerificationCode: { type: 'string', isRequired: 'true', value: '' },
+      otp: { type: 'string', isRequired: 'true', value: '' },
+      stateToken: { type: 'string', isRequired: 'true', value: '' },
     },
-    response_root_field_name: 'response',
+    response_root_field_name: 'data',
     response_required_fields: {
-      id: 'string',
+      accessToken: 'string',
       ttl: 'number',
-      created: 'string',
-      userId: 'string',
+      created: 'string'
     },
     response_optional_fields: {},
     output_fields: {
-      id: { source: 'id', type: 'string', isRequired: true },
+      accessToken: { source: 'accessToken', type: 'string', isRequired: true },
       ttl: { source: 'ttl', type: 'number', isRequired: true },
-      created: { source: 'created', type: 'string', isRequired: true },
-      userId: { source: 'userId', type: 'string', isRequired: true },
+      created: { source: 'created', type: 'string', isRequired: true }
     },
   },
   get_user: {

--- a/src/lib/constants/config.js
+++ b/src/lib/constants/config.js
@@ -1,7 +1,7 @@
 const config = {
   env: {
-    staging: 'https://api-stg.transak.com',
-    production: 'https://api.transak.com',
+    staging: 'https://api-gateway-stg.transak.com',
+    production: 'https://api-gateway.transak.com'
   },
 };
 

--- a/src/lib/services/UserService.js
+++ b/src/lib/services/UserService.js
@@ -4,14 +4,21 @@ class UserService {
     this.partnerApiKey = client.config.partnerApiKey;
   }
 
-  async sendEmailOtp({ email, frontendAuth }) {
-    if (!frontendAuth) throw new Error('Frontend Auth is required');
+  async sendEmailOtp({ email }) {
     return this.client.request({
       endpointId: 'send_email_otp',
-      data: { email, partnerApiKey: this.partnerApiKey },
+      data: { email, apiKey: this.partnerApiKey },
       params: {},
-      headers: { 'frontend-auth': frontendAuth },
     });
+  }
+
+  async verifyEmailOtp(data) {
+    const response = await this.client.request({
+      endpointId: 'verify_email_otp',
+      data: { ...data, apiKey: this.partnerApiKey },
+    });
+    if (response && response.accessToken) await this.client.setAccessToken(response.accessToken);
+    return response;
   }
 
   async requestOtt() {
@@ -21,15 +28,6 @@ class UserService {
       params: {},
       headers: { 'Authorization': `Bearer ${this.client.accessToken}` },
     });
-  }
-
-  async verifyEmailOtp(data) {
-    const response = await this.client.request({
-      endpointId: 'verify_email_otp',
-      data: { ...data, partnerApiKey: this.partnerApiKey },
-    });
-    if (response && response.id) await this.client.setAccessToken(response.id);
-    return response;
   }
 
   async getUser(data) {


### PR DESCRIPTION
### ChangeLog: 
**1️⃣ Send Email OTP API**
Endpoint:
https://api-gateway-stg.transak.com/api/v2/auth/login

Removed frontendAuth parameter
Added apiKey parameter
Simplified request structure

**2️⃣ Verify Email OTP API**
Endpoint:
https://api-gateway-stg.transak.com/api/v2/auth/verify

Added apiKey parameter
Renamed emailVerificationCode to otp
Added stateToken parameter
Updated request structure to match new API specification


